### PR TITLE
文件系统相关commit并入主线

### DIFF
--- a/.github/workflows/actions/setup-musl/action.yml
+++ b/.github/workflows/actions/setup-musl/action.yml
@@ -23,7 +23,7 @@ runs:
       if [ "${{ inputs.arch }}" = "loongarch64" ]; then
         wget https://github.com/LoongsonLab/oscomp-toolchains-for-oskernel/releases/download/loongarch64-linux-musl-cross-gcc-13.2.0/loongarch64-linux-musl-cross.tgz
       else
-        wget https://musl.cc/${MUSL_PATH}.tgz
+        wget https://github.com/elebirds/musl-save/releases/download/musl/${MUSL_PATH}.tgz
       fi
       tar -xf ${MUSL_PATH}.tgz
   - uses: actions/cache/save@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,18 @@ jobs:
         cache-targets: false
     - name: Check rust version
       run: rustc --version --verbose
+    - uses: ./.github/workflows/actions/setup-musl
+      with:
+        arch: x86_64
+    - uses: ./.github/workflows/actions/setup-musl
+      with:
+        arch: riscv64
+    - uses: ./.github/workflows/actions/setup-musl
+      with:
+        arch: aarch64
+    - uses: ./.github/workflows/actions/setup-musl
+      with:
+        arch: loongarch64
     - name: Check code format
       if: ${{ matrix.arch == 'x86_64' }}
       continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,8 +20,9 @@ jobs:
       with:
         toolchain: ${{ env.rust-toolchain }}
     - uses: Swatinem/rust-cache@v2
+    - uses: ./.github/workflows/actions/setup-musl
       with:
-        cache-targets: false
+        arch: x86_64
     - name: Build docs
       continue-on-error: ${{ github.ref != env.default-branch && github.event_name != 'pull_request' }}
       run: make doc_check_missing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,7 +1214,7 @@ dependencies = [
 [[package]]
 name = "lwext4_rust"
 version = "0.2.0"
-source = "git+https://github.com/Azure-stars/lwext4_rust.git#d1561e971c37555428695b12b869ec938af5a058"
+source = "git+https://github.com/Azure-stars/lwext4_rust.git#2e56b0aa2680b210892a46375fefca2bdf6e2865"
 dependencies = [
  "log",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,8 @@ dependencies = [
  "fatfs",
  "lazyinit",
  "log",
+ "lwext4_rust",
+ "spin",
 ]
 
 [[package]]
@@ -1207,6 +1209,14 @@ checksum = "7c9f0d275c70310e2a9d2fc23250c5ac826a73fa828a5f256401f85c5c554283"
 dependencies = [
  "bit_field",
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "lwext4_rust"
+version = "0.2.0"
+source = "git+https://github.com/Azure-stars/lwext4_rust.git#d1561e971c37555428695b12b869ec938af5a058"
+dependencies = [
+ "log",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM rust:slim
 
+RUN apt-get update && apt-get install -y wget
+
 RUN echo /etc/apt/sources.list << deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm main
 RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libclang-19-dev wget make python3 \
-        xz-utils python3-venv ninja-build bzip2 meson \
-        pkg-config libglib2.0-dev git libslirp-dev \
+    && apt-get install -y --no-install-recommends libclang-19-dev make python3 \
+    xz-utils python3-venv ninja-build bzip2 meson \
+    pkg-config libglib2.0-dev git libslirp-dev cmake dosfstools build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 RUN cargo install cargo-binutils axconfig-gen
@@ -29,11 +31,10 @@ RUN wget https://download.qemu.org/qemu-9.2.1.tar.xz \
     && tar xf qemu-9.2.1.tar.xz \
     && cd qemu-9.2.1 \
     && ./configure --prefix=/qemu-bin-9.2.1 \
-        --target-list=loongarch64-softmmu,riscv64-softmmu,aarch64-softmmu,x86_64-softmmu \
-        --enable-gcov --enable-debug --enable-slirp \
+    --target-list=loongarch64-softmmu,riscv64-softmmu,aarch64-softmmu,x86_64-softmmu \
+    --enable-gcov --enable-debug --enable-slirp \
     && make -j$(nproc) \
     && make install
 RUN rm -rf qemu-9.2.1 qemu-9.2.1.tar.xz
 
-ENV PATH="/x86_64-linux-musl-cross/bin:/aarch64-linux-musl-cross/bin:/riscv64-linux-musl-cross/bin:/loongarch64-linux-musl-cross/bin:$PATH"
-ENV PATH="/qemu-bin-9.2.1/bin:$PATH"
+ENV PATH="/x86_64-linux-musl-cross/bin:/aarch64-linux-musl-cross/bin:/riscv64-linux-musl-cross/bin:/loongarch64-linux-musl-cross/bin:/qemu-bin-9.2.1/bin:$PATH"

--- a/api/arceos_posix_api/Cargo.toml
+++ b/api/arceos_posix_api/Cargo.toml
@@ -48,7 +48,7 @@ axns = { workspace = true, optional = true }
 # Other crates
 axio = "0.1"
 axerrno = "0.1"
-flatten_objects = "0.2"
+flatten_objects = { git = "https://github.com/AsakuraMizu/flatten_objects.git", rev = "5b6820b" }
 static_assertions = "1.1.0"
 spin = { version = "0.9" }
 lazy_static = { version = "1.5", features = ["spin_no_std"] }

--- a/api/arceos_posix_api/Cargo.toml
+++ b/api/arceos_posix_api/Cargo.toml
@@ -48,7 +48,7 @@ axns = { workspace = true, optional = true }
 # Other crates
 axio = "0.1"
 axerrno = "0.1"
-flatten_objects = { git = "https://github.com/AsakuraMizu/flatten_objects.git", rev = "5b6820b" }
+flatten_objects = "0.2.3"
 static_assertions = "1.1.0"
 spin = { version = "0.9" }
 lazy_static = { version = "1.5", features = ["spin_no_std"] }

--- a/api/arceos_posix_api/ctypes.h
+++ b/api/arceos_posix_api/ctypes.h
@@ -3,7 +3,6 @@
 #include <netinet/in.h>
 #include <pthread.h>
 #include <stddef.h>
-#include <time.h>
 #include <sys/epoll.h>
 #include <sys/resource.h>
 #include <sys/select.h>
@@ -12,4 +11,5 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/uio.h>
+#include <time.h>
 #include <unistd.h>

--- a/api/arceos_posix_api/src/imp/fd_ops.rs
+++ b/api/arceos_posix_api/src/imp/fd_ops.rs
@@ -31,9 +31,8 @@ impl FD_TABLE {
     pub fn copy_inner(&self) -> RwLock<FlattenObjects<Arc<dyn FileLike>, AX_FILE_LIMIT>> {
         let table = self.read();
         let mut new_table = FlattenObjects::new();
-        let count = table.count();
-        for i in 0..count {
-            let _ = new_table.add_at(i, table.get(i).unwrap().clone());
+        for id in table.ids() {
+            let _ = new_table.add_at(id, table.get(id).unwrap().clone());
         }
         RwLock::new(new_table)
     }

--- a/api/arceos_posix_api/src/imp/fd_ops.rs
+++ b/api/arceos_posix_api/src/imp/fd_ops.rs
@@ -23,9 +23,23 @@ pub trait FileLike: Send + Sync {
 }
 
 def_resource! {
-    pub(crate) static FD_TABLE: ResArc<RwLock<FlattenObjects<Arc<dyn FileLike>, AX_FILE_LIMIT>>> = ResArc::new();
+    pub static FD_TABLE: ResArc<RwLock<FlattenObjects<Arc<dyn FileLike>, AX_FILE_LIMIT>>> = ResArc::new();
 }
 
+impl FD_TABLE {
+    /// Return a copy of the inner table.
+    pub fn copy_inner(&self) -> RwLock<FlattenObjects<Arc<dyn FileLike>, AX_FILE_LIMIT>> {
+        let table = self.read();
+        let mut new_table = FlattenObjects::new();
+        let count = table.count();
+        for i in 0..count {
+            let _ = new_table.add_at(i, table.get(i).unwrap().clone());
+        }
+        RwLock::new(new_table)
+    }
+}
+
+/// Get a file by `fd`.
 pub fn get_file_like(fd: c_int) -> LinuxResult<Arc<dyn FileLike>> {
     FD_TABLE
         .read()
@@ -34,10 +48,12 @@ pub fn get_file_like(fd: c_int) -> LinuxResult<Arc<dyn FileLike>> {
         .ok_or(LinuxError::EBADF)
 }
 
+/// Add a file to the file descriptor table.
 pub fn add_file_like(f: Arc<dyn FileLike>) -> LinuxResult<c_int> {
     Ok(FD_TABLE.write().add(f).map_err(|_| LinuxError::EMFILE)? as c_int)
 }
 
+/// Close a file by `fd`.
 pub fn close_file_like(fd: c_int) -> LinuxResult {
     let f = FD_TABLE
         .write()

--- a/api/arceos_posix_api/src/imp/fs.rs
+++ b/api/arceos_posix_api/src/imp/fs.rs
@@ -1,3 +1,4 @@
+use alloc::string::{String, ToString};
 use alloc::sync::Arc;
 use core::ffi::{c_char, c_int};
 
@@ -7,16 +8,20 @@ use axio::{PollState, SeekFrom};
 use axsync::Mutex;
 
 use super::fd_ops::{FileLike, get_file_like};
+use crate::AT_FDCWD;
 use crate::{ctypes, utils::char_ptr_to_str};
 
+/// File wrapper for `axfs::fops::File`.
 pub struct File {
     inner: Mutex<axfs::fops::File>,
+    path: String,
 }
 
 impl File {
-    fn new(inner: axfs::fops::File) -> Self {
+    fn new(inner: axfs::fops::File, path: String) -> Self {
         Self {
             inner: Mutex::new(inner),
+            path,
         }
     }
 
@@ -29,6 +34,16 @@ impl File {
         f.into_any()
             .downcast::<Self>()
             .map_err(|_| LinuxError::EINVAL)
+    }
+
+    /// Get the path of the file.
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// Get the inner node of the file.    
+    pub fn inner(&self) -> &Mutex<axfs::fops::File> {
+        &self.inner
     }
 }
 
@@ -97,7 +112,11 @@ fn flags_to_options(flags: c_int, _mode: ctypes::mode_t) -> OpenOptions {
         options.create(true);
     }
     if flags & ctypes::O_EXEC != 0 {
-        options.create_new(true);
+        //options.create_new(true);
+        options.execute(true);
+    }
+    if flags & ctypes::O_DIRECTORY != 0 {
+        options.directory(true);
     }
     options
 }
@@ -111,9 +130,87 @@ pub fn sys_open(filename: *const c_char, flags: c_int, mode: ctypes::mode_t) -> 
     debug!("sys_open <= {:?} {:#o} {:#o}", filename, flags, mode);
     syscall_body!(sys_open, {
         let options = flags_to_options(flags, mode);
-        let file = axfs::fops::File::open(filename?, &options)?;
-        File::new(file).add_to_fd_table()
+        if options.has_directory() {
+            return Directory::from_path(filename?.into(), &options)
+                .and_then(Directory::add_to_fd_table);
+        }
+        add_file_or_directory_fd(
+            axfs::fops::File::open,
+            axfs::fops::Directory::open_dir,
+            filename?,
+            &options,
+        )
     })
+}
+
+/// Open or create a file.
+/// fd: file descriptor
+/// filename: file path to be opened or created
+/// flags: open flags
+/// mode: see man 7 inode
+/// return new file descriptor if succeed, or return -1.
+pub fn sys_openat(
+    dirfd: c_int,
+    filename: *const c_char,
+    flags: c_int,
+    mode: ctypes::mode_t,
+) -> c_int {
+    let filename = match char_ptr_to_str(filename) {
+        Ok(s) => s,
+        Err(_) => return -1,
+    };
+
+    debug!(
+        "sys_openat <= {} {:?} {:#o} {:#o}",
+        dirfd, filename, flags, mode
+    );
+
+    let options = flags_to_options(flags, mode);
+
+    if filename.starts_with('/') || dirfd == AT_FDCWD as _ {
+        return sys_open(filename.as_ptr() as _, flags, mode);
+    }
+
+    match Directory::from_fd(dirfd).and_then(|dir| {
+        add_file_or_directory_fd(
+            |filename, options| dir.inner.lock().open_file_at(filename, options),
+            |filename, options| dir.inner.lock().open_dir_at(filename, options),
+            filename,
+            &options,
+        )
+    }) {
+        Ok(fd) => fd,
+        Err(e) => {
+            debug!("sys_openat => {}", e);
+            -1
+        }
+    }
+}
+
+/// Use the function to open file or directory, then add into file descriptor table.
+/// First try opening files, if fails, try directory.
+fn add_file_or_directory_fd<F, D, E>(
+    open_file: F,
+    open_dir: D,
+    filename: &str,
+    options: &OpenOptions,
+) -> LinuxResult<c_int>
+where
+    E: Into<LinuxError>,
+    F: FnOnce(&str, &OpenOptions) -> Result<axfs::fops::File, E>,
+    D: FnOnce(&str, &OpenOptions) -> Result<axfs::fops::Directory, E>,
+{
+    open_file(filename, options)
+        .map_err(Into::into)
+        .map(|f| File::new(f, filename.into()))
+        .and_then(File::add_to_fd_table)
+        .or_else(|e| match e {
+            LinuxError::EISDIR => open_dir(filename, options)
+                .map_err(Into::into)
+                .map(|d| Directory::new(d, filename.into()))
+                .and_then(Directory::add_to_fd_table),
+            _ => Err(e),
+        })
 }
 
 /// Set the position of the file indicated by `fd`.
@@ -146,7 +243,7 @@ pub unsafe fn sys_stat(path: *const c_char, buf: *mut ctypes::stat) -> c_int {
         let mut options = OpenOptions::new();
         options.read(true);
         let file = axfs::fops::File::open(path?, &options)?;
-        let st = File::new(file).stat()?;
+        let st = File::new(file, path?.to_string()).stat()?;
         unsafe { *buf = st };
         Ok(0)
     })
@@ -183,7 +280,6 @@ pub unsafe fn sys_lstat(path: *const c_char, buf: *mut ctypes::stat) -> ctypes::
 }
 
 /// Get the path of the current directory.
-#[allow(clippy::unnecessary_cast)] // `c_char` is either `i8` or `u8`
 pub fn sys_getcwd(buf: *mut c_char, size: usize) -> *mut c_char {
     debug!("sys_getcwd <= {:#x} {}", buf as usize, size);
     syscall_body!(sys_getcwd, {
@@ -215,4 +311,71 @@ pub fn sys_rename(old: *const c_char, new: *const c_char) -> c_int {
         axfs::api::rename(old_path, new_path)?;
         Ok(0)
     })
+}
+
+/// Directory wrapper for `axfs::fops::Directory`.
+pub struct Directory {
+    inner: Mutex<axfs::fops::Directory>,
+    path: String,
+}
+
+impl Directory {
+    fn new(inner: axfs::fops::Directory, path: String) -> Self {
+        Self {
+            inner: Mutex::new(inner),
+            path,
+        }
+    }
+
+    fn from_path(path: String, options: &OpenOptions) -> LinuxResult<Self> {
+        axfs::fops::Directory::open_dir(&path, options)
+            .map_err(Into::into)
+            .map(|d| Self::new(d, path))
+    }
+
+    fn add_to_fd_table(self) -> LinuxResult<c_int> {
+        super::fd_ops::add_file_like(Arc::new(self))
+    }
+
+    /// Open a directory by `fd`.
+    pub fn from_fd(fd: c_int) -> LinuxResult<Arc<Self>> {
+        let f = super::fd_ops::get_file_like(fd)?;
+        f.into_any()
+            .downcast::<Self>()
+            .map_err(|_| LinuxError::EINVAL)
+    }
+
+    /// Get the path of the directory.
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+}
+
+impl FileLike for Directory {
+    fn read(&self, _buf: &mut [u8]) -> LinuxResult<usize> {
+        Err(LinuxError::EBADF)
+    }
+
+    fn write(&self, _buf: &[u8]) -> LinuxResult<usize> {
+        Err(LinuxError::EBADF)
+    }
+
+    fn stat(&self) -> LinuxResult<ctypes::stat> {
+        Err(LinuxError::EBADF)
+    }
+
+    fn into_any(self: Arc<Self>) -> Arc<dyn core::any::Any + Send + Sync> {
+        self
+    }
+
+    fn poll(&self) -> LinuxResult<PollState> {
+        Ok(PollState {
+            readable: true,
+            writable: false,
+        })
+    }
+
+    fn set_nonblocking(&self, _nonblocking: bool) -> LinuxResult {
+        Ok(())
+    }
 }

--- a/api/arceos_posix_api/src/imp/io.rs
+++ b/api/arceos_posix_api/src/imp/io.rs
@@ -1,5 +1,5 @@
 use crate::ctypes;
-use axerrno::LinuxError;
+use axerrno::{LinuxError, LinuxResult};
 use core::ffi::{c_int, c_void};
 
 #[cfg(feature = "fd")]
@@ -30,27 +30,29 @@ pub fn sys_read(fd: c_int, buf: *mut c_void, count: usize) -> ctypes::ssize_t {
     })
 }
 
+fn write_impl(fd: c_int, buf: *const c_void, count: usize) -> LinuxResult<ctypes::ssize_t> {
+    if buf.is_null() {
+        return Err(LinuxError::EFAULT);
+    }
+    let src = unsafe { core::slice::from_raw_parts(buf as *const u8, count) };
+    #[cfg(feature = "fd")]
+    {
+        Ok(get_file_like(fd)?.write(src)? as ctypes::ssize_t)
+    }
+    #[cfg(not(feature = "fd"))]
+    match fd {
+        0 => Err(LinuxError::EPERM),
+        1 | 2 => Ok(super::stdio::stdout().write(src)? as ctypes::ssize_t),
+        _ => Err(LinuxError::EBADF),
+    }
+}
+
 /// Write data to the file indicated by `fd`.
 ///
 /// Return the written size if success.
 pub fn sys_write(fd: c_int, buf: *const c_void, count: usize) -> ctypes::ssize_t {
     debug!("sys_write <= {} {:#x} {}", fd, buf as usize, count);
-    syscall_body!(sys_write, {
-        if buf.is_null() {
-            return Err(LinuxError::EFAULT);
-        }
-        let src = unsafe { core::slice::from_raw_parts(buf as *const u8, count) };
-        #[cfg(feature = "fd")]
-        {
-            Ok(get_file_like(fd)?.write(src)? as ctypes::ssize_t)
-        }
-        #[cfg(not(feature = "fd"))]
-        match fd {
-            0 => Err(LinuxError::EPERM),
-            1 | 2 => Ok(super::stdio::stdout().write(src)? as ctypes::ssize_t),
-            _ => Err(LinuxError::EBADF),
-        }
-    })
+    syscall_body!(sys_write, write_impl(fd, buf, count))
 }
 
 /// Write a vector.
@@ -64,7 +66,7 @@ pub unsafe fn sys_writev(fd: c_int, iov: *const ctypes::iovec, iocnt: c_int) -> 
         let iovs = unsafe { core::slice::from_raw_parts(iov, iocnt as usize) };
         let mut ret = 0;
         for iov in iovs.iter() {
-            ret += sys_write(fd, iov.iov_base, iov.iov_len);
+            ret += write_impl(fd, iov.iov_base, iov.iov_len)?;
         }
 
         Ok(ret)

--- a/api/arceos_posix_api/src/imp/io.rs
+++ b/api/arceos_posix_api/src/imp/io.rs
@@ -66,10 +66,7 @@ pub unsafe fn sys_writev(fd: c_int, iov: *const ctypes::iovec, iocnt: c_int) -> 
         let iovs = unsafe { core::slice::from_raw_parts(iov, iocnt as usize) };
         let mut ret = 0;
         for iov in iovs.iter() {
-            let result = sys_write(fd, iov.iov_base, iov.iov_len);
-            if result < 0 {
-                return Ok(result);
-            }
+            let result = write_impl(fd, iov.iov_base, iov.iov_len)?;
             ret += result;
 
             if result < iov.iov_len as isize {

--- a/api/arceos_posix_api/src/imp/io.rs
+++ b/api/arceos_posix_api/src/imp/io.rs
@@ -66,7 +66,15 @@ pub unsafe fn sys_writev(fd: c_int, iov: *const ctypes::iovec, iocnt: c_int) -> 
         let iovs = unsafe { core::slice::from_raw_parts(iov, iocnt as usize) };
         let mut ret = 0;
         for iov in iovs.iter() {
-            ret += write_impl(fd, iov.iov_base, iov.iov_len)?;
+            let result = sys_write(fd, iov.iov_base, iov.iov_len);
+            if result < 0 {
+                return Ok(result);
+            }
+            ret += result;
+
+            if result < iov.iov_len as isize {
+                break;
+            }
         }
 
         Ok(ret)

--- a/api/arceos_posix_api/src/imp/mod.rs
+++ b/api/arceos_posix_api/src/imp/mod.rs
@@ -14,6 +14,8 @@ pub mod fs;
 pub mod io_mpx;
 #[cfg(feature = "net")]
 pub mod net;
+#[cfg(feature = "fs")]
+pub mod path_link;
 #[cfg(feature = "pipe")]
 pub mod pipe;
 #[cfg(feature = "multitask")]

--- a/api/arceos_posix_api/src/imp/path_link.rs
+++ b/api/arceos_posix_api/src/imp/path_link.rs
@@ -1,0 +1,392 @@
+use alloc::collections::BTreeMap;
+use alloc::format;
+use core::fmt;
+use core::ops::Deref;
+use spin::RwLock;
+
+use alloc::string::{String, ToString};
+use axerrno::{AxError, AxResult};
+use axfs::api::{canonicalize, current_dir};
+
+use super::fd_ops::FD_TABLE;
+
+/// 一个规范化的文件路径表示
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+pub struct FilePath(String);
+
+impl FilePath {
+    /// 从路径字符串创建一个新的 `FilePath`，路径将被规范化。
+    /// 输入路径可以是绝对路径或相对路径。
+    pub fn new<P: AsRef<str>>(path: P) -> AxResult<Self> {
+        let path = path.as_ref();
+        let canonical = canonicalize(path).map_err(|_| AxError::NotFound)?;
+        let mut new_path = canonical.trim().to_string();
+
+        // 如果原始路径以 '/' 结尾，那么规范化后的路径也应以 '/' 结尾
+        if path.ends_with('/') && !new_path.ends_with('/') {
+            new_path.push('/');
+        }
+
+        assert!(
+            new_path.starts_with('/'),
+            "canonical path should start with /"
+        );
+
+        Ok(Self(HARDLINK_MANAGER.real_path(&new_path)))
+    }
+
+    /// 返回底层路径的字符串切片
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// 返回父目录路径
+    pub fn parent(&self) -> AxResult<&str> {
+        if self.is_root() {
+            return Ok("/");
+        }
+
+        // 查找最后一个斜杠，考虑可能的尾部斜杠
+        let mut path = self.as_str();
+        if path.ends_with('/') {
+            path = path.strip_suffix('/').unwrap();
+        }
+        let pos = path.rfind('/').ok_or(AxError::NotFound)?;
+
+        Ok(&path[..=pos])
+    }
+
+    /// 返回文件名或目录名组件
+    pub fn name(&self) -> AxResult<&str> {
+        if self.is_root() {
+            return Ok("/");
+        }
+
+        let mut path = self.as_str();
+        if path.ends_with('/') {
+            path = path.strip_suffix('/').unwrap();
+        }
+        let start_pos = path.rfind('/').ok_or(AxError::NotFound)?;
+
+        let end_pos = if path.ends_with('/') {
+            path.len() - 1
+        } else {
+            path.len()
+        };
+        Ok(&path[start_pos + 1..end_pos])
+    }
+
+    /// 判断是否为根目录
+    pub fn is_root(&self) -> bool {
+        self.0 == "/"
+    }
+
+    /// 判断是否为目录（以 '/' 结尾）
+    pub fn is_dir(&self) -> bool {
+        self.0.ends_with('/')
+    }
+
+    /// 判断是否为常规文件（不以 '/' 结尾）
+    pub fn is_file(&self) -> bool {
+        !self.is_dir()
+    }
+
+    /// Whether the path exists
+    pub fn exists(&self) -> bool {
+        axfs::api::absolute_path_exists(&self.0)
+    }
+
+    /// 判断此路径是否以给定前缀路径开头
+    pub fn starts_with(&self, prefix: &FilePath) -> bool {
+        self.0.starts_with(&prefix.0)
+    }
+
+    /// 判断此路径是否以给定后缀路径结尾
+    pub fn ends_with(&self, suffix: &FilePath) -> bool {
+        self.0.ends_with(&suffix.0)
+    }
+
+    /// 将此路径与相对路径组件连接
+    pub fn join<P: AsRef<str>>(&self, path: P) -> AxResult<Self> {
+        let mut new_path = self.0.clone();
+        if !new_path.ends_with('/') {
+            new_path.push('/');
+        }
+        new_path.push_str(path.as_ref());
+        FilePath::new(new_path)
+    }
+
+    /// 返回此路径组件的迭代器
+    pub fn components(&self) -> impl Iterator<Item = &str> {
+        self.0.trim_matches('/').split('/')
+    }
+}
+
+impl fmt::Display for FilePath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for FilePath {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for FilePath {
+    fn from(s: &str) -> Self {
+        FilePath::new(s).unwrap()
+    }
+}
+
+impl Deref for FilePath {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// 错误类型
+#[derive(Debug)]
+pub enum LinkError {
+    LinkExists,  // 链接已存在
+    InvalidPath, // 无效路径
+    NotFound,    // 文件不存在
+    NotFile,     // 不是文件
+}
+
+impl From<LinkError> for AxError {
+    fn from(err: LinkError) -> AxError {
+        match err {
+            LinkError::LinkExists => AxError::AlreadyExists,
+            LinkError::InvalidPath => AxError::InvalidInput,
+            LinkError::NotFound => AxError::NotFound,
+            LinkError::NotFile => AxError::InvalidInput,
+        }
+    }
+}
+
+/// A global hardlink manager
+pub static HARDLINK_MANAGER: HardlinkManager = HardlinkManager::new();
+
+/// A manager for hardlinks
+pub struct HardlinkManager {
+    inner: RwLock<LinkManagerInner>,
+}
+struct LinkManagerInner {
+    links: BTreeMap<String, String>,
+    ref_counts: BTreeMap<String, usize>,
+}
+
+// 关于innner的操作都在atomic_开头的函数中
+impl HardlinkManager {
+    pub const fn new() -> Self {
+        Self {
+            inner: RwLock::new(LinkManagerInner {
+                links: BTreeMap::new(),
+                ref_counts: BTreeMap::new(),
+            }),
+        }
+    }
+
+    /// 创建链接
+    /// 如果目标路径不存在，则返回 `LinkError::NotFound`
+    /// 如果目标路径不是文件，则返回 `LinkError::NotFile`
+    pub fn create_link(&self, src: &FilePath, dst: &FilePath) -> Result<(), LinkError> {
+        if !dst.exists() {
+            return Err(LinkError::NotFound);
+        }
+        if !dst.is_dir() {
+            return Err(LinkError::NotFile);
+        }
+
+        let mut inner = self.inner.write();
+        self.atomic_link_update(&mut inner, src, dst);
+        Ok(())
+    }
+
+    /// 移除链接
+    /// 链接数量为零 或 没有链接时， 删除文件
+    /// 如果路径对应的链接不存在 或 路径对应的文件不存在，则返回 `None`
+    /// 否则返回链接的目标路径
+    pub fn remove_link(&self, src: &FilePath) -> Option<String> {
+        let mut inner = self.inner.write();
+        self.atomic_link_remove(&mut inner, src).or_else(|| {
+            axfs::api::remove_file(src.as_str())
+                .ok()
+                .map(|_| src.to_string())
+        })
+    }
+
+    pub fn real_path(&self, path: &str) -> String {
+        self.inner
+            .read()
+            .links
+            .get(path)
+            .cloned()
+            .unwrap_or_else(|| path.to_string())
+    }
+
+    pub fn link_count(&self, path: &FilePath) -> usize {
+        let inner = self.inner.read();
+        inner
+            .ref_counts
+            .get(path.as_str())
+            .copied()
+            .unwrap_or_else(|| if path.exists() { 1 } else { 0 })
+    }
+
+    // 原子操作helpers
+
+    /// 创建或更新链接
+    /// 如果链接已存在，则更新目标路径
+    /// 如果目标路径不存在，则返回 `LinkError::NotFound`
+    fn atomic_link_update(&self, inner: &mut LinkManagerInner, src: &FilePath, dst: &FilePath) {
+        if let Some(old_dst) = inner.links.get(src.as_str()) {
+            if old_dst == dst.as_str() {
+                return;
+            }
+            self.decrease_ref_count(inner, &old_dst.to_string());
+        }
+        inner.links.insert(src.to_string(), dst.to_string());
+        *inner.ref_counts.entry(dst.to_string()).or_insert(0) += 1;
+    }
+
+    /// 移除链接
+    /// 如果链接不存在，则返回 `None`，否则返回链接的目标路径
+    fn atomic_link_remove(&self, inner: &mut LinkManagerInner, src: &FilePath) -> Option<String> {
+        inner.links.remove(src.as_str()).inspect(|dst| {
+            self.decrease_ref_count(inner, dst);
+        })
+    }
+
+    /// 减少引用计数
+    /// 如果引用计数为零，则删除链接，并删除文件，如果删除文件失败，则返回 `None`
+    /// 如果链接不存在，则返回 `None`
+    fn decrease_ref_count(&self, inner: &mut LinkManagerInner, path: &str) -> Option<()> {
+        match inner.ref_counts.get_mut(path) {
+            Some(count) => {
+                *count -= 1;
+                if *count == 0 {
+                    inner.ref_counts.remove(path);
+                    axfs::api::remove_file(path).ok()?
+                }
+                Some(())
+            }
+            None => {
+                axlog::error!("link exists but ref count is zero");
+                None
+            }
+        }
+    }
+}
+
+/// A constant representing the current working directory
+pub const AT_FDCWD: isize = -100;
+
+/// 处理路径并返回规范化后的 `FilePath`
+///
+/// * `dir_fd` - 目录的文件描述符，如果是 `AT_FDCWD`，则操作当前工作目录
+///
+/// * `path_addr` - 路径的地址，如果为 `None`，则操作由 `dir_fd` 指定的文件
+///
+/// * `force_dir` - 如果为 `true`，则将路径视为目录
+///
+/// 该函数会处理链接并规范化路径
+pub fn handle_file_path(
+    dir_fd: isize,
+    path_addr: Option<*const u8>,
+    force_dir: bool,
+) -> AxResult<FilePath> {
+    // 获取路径字符串
+    let path = match path_addr {
+        Some(addr) => {
+            if addr.is_null() {
+                axlog::warn!("路径地址为空");
+                return Err(AxError::BadAddress);
+            }
+            crate::utils::char_ptr_to_str(addr as *const _)
+                .map_err(|_| AxError::NotFound)?
+                .to_string()
+        }
+        None => String::new(),
+    };
+
+    // 处理空路径的情况
+    let mut path = if path.is_empty() {
+        handle_empty_path(dir_fd)?
+    } else {
+        path
+    };
+
+    // 处理相对路径的情况
+    if !path.starts_with('/') {
+        if dir_fd == AT_FDCWD {
+            path = prepend_cwd(&path)?;
+        } else {
+            path = handle_relative_path(dir_fd, &path)?;
+        }
+    }
+
+    // 根据 `force_dir` 和路径结尾调整路径
+    path = adjust_path_suffix(path, force_dir);
+
+    // 创建并返回 `FilePath`
+    FilePath::new(&path)
+}
+
+fn handle_empty_path(dir_fd: isize) -> AxResult<String> {
+    const AT_FDCWD: isize = -100;
+    if dir_fd == AT_FDCWD {
+        return Ok(String::from("."));
+    }
+
+    let fd_table = FD_TABLE.write();
+    if dir_fd >= fd_table.count() as isize || dir_fd < 0 {
+        axlog::warn!("文件描述符索引超出范围");
+        return Err(AxError::InvalidInput);
+    }
+    super::fs::Directory::from_fd(dir_fd as i32)
+        .map(|dir| dir.path().to_string())
+        .map_err(|_| AxError::NotFound)
+}
+
+fn handle_relative_path(dir_fd: isize, path: &str) -> AxResult<String> {
+    let fd_table = FD_TABLE.write();
+    if dir_fd >= fd_table.count() as isize || dir_fd < 0 {
+        axlog::warn!("文件描述符索引超出范围");
+        return Err(AxError::InvalidInput);
+    }
+    match super::fs::Directory::from_fd(dir_fd as i32) {
+        Ok(dir) => {
+            // 假设目录路径以 '/' 结尾，无需手动添加
+            let combined_path = format!("{}{}", dir.path(), path);
+            axlog::info!("处理后的路径: {} (目录: {})", combined_path, dir.path());
+            Ok(combined_path)
+        }
+        Err(_) => {
+            axlog::warn!("文件描述符不存在");
+            Err(AxError::NotFound)
+        }
+    }
+}
+
+fn prepend_cwd(path: &str) -> AxResult<String> {
+    let cwd = current_dir().map_err(|_| AxError::NotFound)?;
+    debug_assert!(cwd.ends_with('/'), "当前工作目录路径应以 '/' 结尾");
+    Ok(format!("{}{}", cwd, path))
+}
+
+/// 根据 `force_dir` 和路径结尾调整路径
+fn adjust_path_suffix(mut path: String, force_dir: bool) -> String {
+    if force_dir && !path.ends_with('/') {
+        path.push('/');
+    }
+    if path.ends_with('.') {
+        // 防止路径以 '.' 结尾
+        path.push('/');
+    }
+    path
+}

--- a/api/arceos_posix_api/src/imp/time.rs
+++ b/api/arceos_posix_api/src/imp/time.rs
@@ -90,3 +90,17 @@ pub unsafe fn sys_nanosleep(req: *const ctypes::timespec, rem: *mut ctypes::time
         Ok(0)
     })
 }
+
+/// Get current system time and store in specific struct
+pub unsafe fn sys_get_time_of_day(ts: *mut ctypes::timeval) -> c_int {
+    syscall_body!(sys_get_time_of_day, {
+        let current_us = axhal::time::monotonic_time_nanos() as usize / 1000;
+        unsafe {
+            *ts = ctypes::timeval {
+                tv_sec: (current_us / 1_000_000) as i64,
+                tv_usec: (current_us % 1_000_000) as i64,
+            }
+        }
+        Ok(0)
+    })
+}

--- a/api/arceos_posix_api/src/lib.rs
+++ b/api/arceos_posix_api/src/lib.rs
@@ -18,6 +18,7 @@ extern crate alloc;
 mod utils;
 
 mod imp;
+pub use utils::char_ptr_to_str;
 
 /// Platform-specific constants and parameters.
 pub mod config {
@@ -31,15 +32,22 @@ pub mod config {
 pub mod ctypes;
 
 pub use imp::io::{sys_read, sys_write, sys_writev};
+#[cfg(feature = "fs")]
+pub use imp::path_link::{AT_FDCWD, FilePath, HARDLINK_MANAGER, handle_file_path};
 pub use imp::resources::{sys_getrlimit, sys_setrlimit};
 pub use imp::sys::sys_sysconf;
 pub use imp::task::{sys_exit, sys_getpid, sys_sched_yield};
-pub use imp::time::{sys_clock_gettime, sys_nanosleep};
+pub use imp::time::{sys_clock_gettime, sys_get_time_of_day, sys_nanosleep};
 
 #[cfg(feature = "fd")]
-pub use imp::fd_ops::{sys_close, sys_dup, sys_dup2, sys_fcntl};
+pub use imp::fd_ops::{
+    FD_TABLE, add_file_like, get_file_like, sys_close, sys_dup, sys_dup2, sys_fcntl,
+};
 #[cfg(feature = "fs")]
-pub use imp::fs::{sys_fstat, sys_getcwd, sys_lseek, sys_lstat, sys_open, sys_rename, sys_stat};
+pub use imp::fs::{
+    Directory, File, sys_fstat, sys_getcwd, sys_lseek, sys_lstat, sys_open, sys_openat, sys_rename,
+    sys_stat,
+};
 #[cfg(feature = "select")]
 pub use imp::io_mpx::sys_select;
 #[cfg(feature = "epoll")]

--- a/api/arceos_posix_api/src/utils.rs
+++ b/api/arceos_posix_api/src/utils.rs
@@ -4,10 +4,12 @@
 use axerrno::{LinuxError, LinuxResult};
 use core::ffi::{CStr, c_char};
 
+/// Convert a C string to a Rust string
 pub fn char_ptr_to_str<'a>(str: *const c_char) -> LinuxResult<&'a str> {
     if str.is_null() {
         Err(LinuxError::EFAULT)
     } else {
+        let str = str as *const _;
         unsafe { CStr::from_ptr(str) }
             .to_str()
             .map_err(|_| LinuxError::EINVAL)

--- a/api/axfeat/Cargo.toml
+++ b/api/axfeat/Cargo.toml
@@ -41,6 +41,7 @@ sched_cfs = ["axtask/sched_cfs", "irq"]
 # File system
 fs = ["alloc", "paging", "axdriver/virtio-blk", "dep:axfs", "axruntime/fs"] # TODO: try to remove "paging"
 myfs = ["axfs?/myfs"]
+lwext4_rs = ["axfs/lwext4_rs"]
 
 # Networking
 net = ["alloc", "paging", "axdriver/virtio-net", "dep:axnet", "axruntime/net"]

--- a/modules/axfs/Cargo.toml
+++ b/modules/axfs/Cargo.toml
@@ -26,7 +26,7 @@ log = "=0.4.21"
 cfg-if = "1.0"
 lazyinit = "0.2"
 cap_access = "0.1"
-axio = { version = "0.1", features = ["alloc"] }
+axio = { version = "0.1.1", features = ["alloc"] }
 axerrno = "0.1"
 axfs_vfs = "0.1"
 spin = "0.9"

--- a/modules/axfs/Cargo.toml
+++ b/modules/axfs/Cargo.toml
@@ -14,6 +14,7 @@ devfs = ["dep:axfs_devfs"]
 ramfs = ["dep:axfs_ramfs"]
 procfs = ["dep:axfs_ramfs"]
 sysfs = ["dep:axfs_ramfs"]
+lwext4_rs = ["dep:lwext4_rust"]
 fatfs = ["dep:fatfs"]
 myfs = ["dep:crate_interface"]
 use-ramdisk = []
@@ -28,12 +29,14 @@ cap_access = "0.1"
 axio = { version = "0.1", features = ["alloc"] }
 axerrno = "0.1"
 axfs_vfs = "0.1"
+spin = "0.9"
 axfs_devfs = { version = "0.1", optional = true }
 axfs_ramfs = { version = "0.1", optional = true }
 crate_interface = { version = "0.1", optional = true }
 axsync = { workspace = true }
 axdriver = { workspace = true, features = ["block"] }
 axdriver_block = { git = "https://github.com/arceos-org/axdriver_crates.git", tag = "v0.1.2" }
+lwext4_rust = { git = "https://github.com/Azure-stars/lwext4_rust.git", default-features = false, optional = true }
 axns = { workspace = true }
 
 [dependencies.fatfs]

--- a/modules/axfs/src/api/file.rs
+++ b/modules/axfs/src/api/file.rs
@@ -1,4 +1,5 @@
-use axio::{Result, SeekFrom, prelude::*};
+use alloc::vec::Vec;
+use axio::{Result, SeekFrom, default_read_to_end, prelude::*};
 use core::fmt;
 
 use crate::fops;
@@ -173,6 +174,14 @@ impl File {
 impl Read for File {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         self.inner.read(buf)
+    }
+
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+        default_read_to_end(
+            self,
+            buf,
+            self.metadata().ok().map(|metadata| metadata.size() as _),
+        )
     }
 }
 

--- a/modules/axfs/src/api/file.rs
+++ b/modules/axfs/src/api/file.rs
@@ -17,17 +17,11 @@ pub struct File {
 }
 
 /// Metadata information about a file.
-pub struct Metadata(fops::FileAttr);
+pub struct Metadata(pub(super) fops::FileAttr);
 
 /// Options and flags which can be used to configure how a file is opened.
-#[derive(Clone, Debug)]
+#[derive(Default, Clone, Debug)]
 pub struct OpenOptions(fops::OpenOptions);
-
-impl Default for OpenOptions {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 impl OpenOptions {
     /// Creates a blank new set of options ready for configuration.

--- a/modules/axfs/src/api/mod.rs
+++ b/modules/axfs/src/api/mod.rs
@@ -87,3 +87,8 @@ pub fn remove_file(path: &str) -> io::Result<()> {
 pub fn rename(old: &str, new: &str) -> io::Result<()> {
     crate::root::rename(old, new)
 }
+
+/// check whether absolute path exists.
+pub fn absolute_path_exists(path: &str) -> bool {
+    crate::root::lookup(None, path).is_ok()
+}

--- a/modules/axfs/src/api/mod.rs
+++ b/modules/axfs/src/api/mod.rs
@@ -56,7 +56,7 @@ pub fn write<C: AsRef<[u8]>>(path: &str, contents: C) -> io::Result<()> {
 /// Given a path, query the file system to get information about a file,
 /// directory, etc.
 pub fn metadata(path: &str) -> io::Result<Metadata> {
-    File::open(path)?.metadata()
+    crate::root::lookup(None, path)?.get_attr().map(Metadata)
 }
 
 /// Creates a new, empty directory at the provided path.

--- a/modules/axfs/src/fops.rs
+++ b/modules/axfs/src/fops.rs
@@ -40,19 +40,15 @@ pub struct OpenOptions {
     // generic
     read: bool,
     write: bool,
+    execute: bool,
     append: bool,
     truncate: bool,
     create: bool,
     create_new: bool,
+    directory: bool,
     // system-specific
     _custom_flags: i32,
     _mode: u32,
-}
-
-impl Default for OpenOptions {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl OpenOptions {
@@ -62,10 +58,12 @@ impl OpenOptions {
             // generic
             read: false,
             write: false,
+            execute: false,
             append: false,
             truncate: false,
             create: false,
             create_new: false,
+            directory: false,
             // system-specific
             _custom_flags: 0,
             _mode: 0o666,
@@ -78,6 +76,10 @@ impl OpenOptions {
     /// Sets the option for write access.
     pub fn write(&mut self, write: bool) {
         self.write = write;
+    }
+    /// Sets the option for execute access.
+    pub fn execute(&mut self, execute: bool) {
+        self.execute = execute;
     }
     /// Sets the option for the append mode.
     pub fn append(&mut self, append: bool) {
@@ -95,9 +97,36 @@ impl OpenOptions {
     pub fn create_new(&mut self, create_new: bool) {
         self.create_new = create_new;
     }
+    /// Sets the option to open a directory.
+    pub fn directory(&mut self, directory: bool) {
+        self.directory = directory;
+    }
+    /// check whether contains directory.
+    pub fn has_directory(&self) -> bool {
+        self.directory
+    }
+
+    /// Sets the create flags.
+    pub fn set_create(mut self, create: bool, create_new: bool) -> Self {
+        self.create = create;
+        self.create_new = create_new;
+        self
+    }
+
+    /// Sets the read flag.
+    pub fn set_read(mut self, read: bool) -> Self {
+        self.read = read;
+        self
+    }
+
+    /// Sets the write flag.
+    pub fn set_write(mut self, write: bool) -> Self {
+        self.write = write;
+        self
+    }
 
     const fn is_valid(&self) -> bool {
-        if !self.read && !self.write && !self.append {
+        if !self.read && !self.write && !self.append && !self.directory {
             return false;
         }
         match (self.write, self.append) {
@@ -398,6 +427,9 @@ impl From<&OpenOptions> for Cap {
         }
         if opts.write | opts.append {
             cap |= Cap::WRITE;
+        }
+        if opts.execute {
+            cap |= Cap::EXECUTE;
         }
         cap
     }

--- a/modules/axfs/src/fs/lwext4_rust.rs
+++ b/modules/axfs/src/fs/lwext4_rust.rs
@@ -1,0 +1,404 @@
+use crate::alloc::string::String;
+use alloc::sync::Arc;
+use axerrno::AxError;
+use axfs_vfs::{VfsDirEntry, VfsError, VfsNodePerm, VfsResult};
+use axfs_vfs::{VfsNodeAttr, VfsNodeOps, VfsNodeRef, VfsNodeType, VfsOps};
+use axsync::Mutex;
+use lwext4_rust::bindings::{
+    O_CREAT, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY, SEEK_CUR, SEEK_END, SEEK_SET,
+};
+use lwext4_rust::{Ext4BlockWrapper, Ext4File, InodeTypes, KernelDevOp};
+
+use crate::dev::Disk;
+pub const BLOCK_SIZE: usize = 512;
+
+#[allow(dead_code)]
+pub struct Ext4FileSystem {
+    inner: Ext4BlockWrapper<Disk>,
+    root: VfsNodeRef,
+}
+
+unsafe impl Sync for Ext4FileSystem {}
+unsafe impl Send for Ext4FileSystem {}
+
+impl Ext4FileSystem {
+    #[cfg(feature = "use-ramdisk")]
+    pub fn new(mut disk: Disk) -> Self {
+        unimplemented!()
+    }
+
+    #[cfg(not(feature = "use-ramdisk"))]
+    pub fn new(disk: Disk) -> Self {
+        info!(
+            "Got Disk size:{}, position:{}",
+            disk.size(),
+            disk.position()
+        );
+        let inner =
+            Ext4BlockWrapper::<Disk>::new(disk).expect("failed to initialize EXT4 filesystem");
+        let root = Arc::new(FileWrapper::new("/", InodeTypes::EXT4_DE_DIR));
+        Self { inner, root }
+    }
+}
+
+/// The [`VfsOps`] trait provides operations on a filesystem.
+impl VfsOps for Ext4FileSystem {
+    // mount()
+
+    fn root_dir(&self) -> VfsNodeRef {
+        debug!("Get root_dir");
+        //let root_dir = unsafe { (*self.root.get()).as_ref().unwrap() };
+        Arc::clone(&self.root)
+    }
+}
+
+pub struct FileWrapper(Mutex<Ext4File>);
+
+unsafe impl Send for FileWrapper {}
+unsafe impl Sync for FileWrapper {}
+
+impl FileWrapper {
+    fn new(path: &str, types: InodeTypes) -> Self {
+        info!("FileWrapper new {:?} {}", types, path);
+        //file.file_read_test("/test/test.txt", &mut buf);
+
+        Self(Mutex::new(Ext4File::new(path, types)))
+    }
+
+    fn path_deal_with(&self, path: &str) -> String {
+        if path.starts_with('/') {
+            warn!("path_deal_with: {}", path);
+        }
+        let p = path.trim_matches('/'); // 首尾去除
+        if p.is_empty() || p == "." {
+            return String::new();
+        }
+
+        if let Some(rest) = p.strip_prefix("./") {
+            //if starts with "./"
+            return self.path_deal_with(rest);
+        }
+        let rest_p = p.replace("//", "/");
+        if p != rest_p {
+            return self.path_deal_with(&rest_p);
+        }
+
+        //Todo ? ../
+        //注：lwext4创建文件必须提供文件path的绝对路径
+        let file = self.0.lock();
+        let path = file.get_path();
+        let fpath = String::from(path.to_str().unwrap().trim_end_matches('/')) + "/" + p;
+        info!("dealt with full path: {}", fpath.as_str());
+        fpath
+    }
+}
+
+/// The [`VfsNodeOps`] trait provides operations on a file or a directory.
+impl VfsNodeOps for FileWrapper {
+    fn get_attr(&self) -> VfsResult<VfsNodeAttr> {
+        let mut file = self.0.lock();
+
+        let perm = file.file_mode_get().unwrap_or(0o755);
+        let perm = VfsNodePerm::from_bits_truncate((perm as u16) & 0o777);
+
+        let vtype = file.file_type_get();
+        let vtype = match vtype {
+            InodeTypes::EXT4_INODE_MODE_FIFO => VfsNodeType::Fifo,
+            InodeTypes::EXT4_INODE_MODE_CHARDEV => VfsNodeType::CharDevice,
+            InodeTypes::EXT4_INODE_MODE_DIRECTORY => VfsNodeType::Dir,
+            InodeTypes::EXT4_INODE_MODE_BLOCKDEV => VfsNodeType::BlockDevice,
+            InodeTypes::EXT4_INODE_MODE_FILE => VfsNodeType::File,
+            InodeTypes::EXT4_INODE_MODE_SOFTLINK => VfsNodeType::SymLink,
+            InodeTypes::EXT4_INODE_MODE_SOCKET => VfsNodeType::Socket,
+            _ => {
+                warn!("unknown file type: {:?}", vtype);
+                VfsNodeType::File
+            }
+        };
+
+        let size = if vtype == VfsNodeType::File {
+            let path = file.get_path();
+            let path = path.to_str().unwrap();
+            file.file_open(path, O_RDONLY)
+                .map_err(|e| <i32 as TryInto<AxError>>::try_into(e).unwrap())?;
+            let fsize = file.file_size();
+            let _ = file.file_close();
+            fsize
+        } else {
+            0 // DIR size ?
+        };
+        let blocks = (size + (BLOCK_SIZE as u64 - 1)) / BLOCK_SIZE as u64;
+
+        info!(
+            "get_attr of {:?} {:?}, size: {}, blocks: {}",
+            vtype,
+            file.get_path(),
+            size,
+            blocks
+        );
+
+        Ok(VfsNodeAttr::new(perm, vtype, size, blocks))
+    }
+
+    fn create(&self, path: &str, ty: VfsNodeType) -> VfsResult {
+        info!("create {:?} on Ext4fs: {}", ty, path);
+        let fpath = self.path_deal_with(path);
+        let fpath = fpath.as_str();
+        if fpath.is_empty() {
+            return Ok(());
+        }
+
+        let types = match ty {
+            VfsNodeType::Fifo => InodeTypes::EXT4_DE_FIFO,
+            VfsNodeType::CharDevice => InodeTypes::EXT4_DE_CHRDEV,
+            VfsNodeType::Dir => InodeTypes::EXT4_DE_DIR,
+            VfsNodeType::BlockDevice => InodeTypes::EXT4_DE_BLKDEV,
+            VfsNodeType::File => InodeTypes::EXT4_DE_REG_FILE,
+            VfsNodeType::SymLink => InodeTypes::EXT4_DE_SYMLINK,
+            VfsNodeType::Socket => InodeTypes::EXT4_DE_SOCK,
+        };
+
+        let mut file = self.0.lock();
+        if file.check_inode_exist(fpath, types.clone()) {
+            Ok(())
+        } else {
+            if types == InodeTypes::EXT4_DE_DIR {
+                file.dir_mk(fpath)
+                    .map(|_v| ())
+                    .map_err(|e| e.try_into().unwrap())
+            } else {
+                file.file_open(fpath, O_WRONLY | O_CREAT | O_TRUNC)
+                    .expect("create file failed");
+                file.file_close()
+                    .map(|_v| ())
+                    .map_err(|e| e.try_into().unwrap())
+            }
+        }
+    }
+
+    fn remove(&self, path: &str) -> VfsResult {
+        info!("remove ext4fs: {}", path);
+        let fpath = self.path_deal_with(path);
+        let fpath = fpath.as_str();
+
+        assert!(!fpath.is_empty()); // already check at `root.rs`
+
+        let mut file = self.0.lock();
+        if file.check_inode_exist(fpath, InodeTypes::EXT4_DE_DIR) {
+            // Recursive directory remove
+            file.dir_rm(fpath)
+                .map(|_v| ())
+                .map_err(|e| e.try_into().unwrap())
+        } else {
+            file.file_remove(fpath)
+                .map(|_v| ())
+                .map_err(|e| e.try_into().unwrap())
+        }
+    }
+
+    /// Get the parent directory of this directory.
+    /// Return `None` if the node is a file.
+    fn parent(&self) -> Option<VfsNodeRef> {
+        let file = self.0.lock();
+        if file.get_type() == InodeTypes::EXT4_DE_DIR {
+            let path = file.get_path();
+            let path = path.to_str().unwrap();
+            info!("Get the parent dir of {}", path);
+            let path = path.trim_end_matches('/').trim_end_matches(|c| c != '/');
+            if !path.is_empty() {
+                return Some(Arc::new(Self::new(path, InodeTypes::EXT4_DE_DIR)));
+            }
+        }
+        None
+    }
+
+    /// Read directory entries into `dirents`, starting from `start_idx`.
+    fn read_dir(&self, start_idx: usize, dirents: &mut [VfsDirEntry]) -> VfsResult<usize> {
+        let file = self.0.lock();
+        let (name, inode_type) = file.lwext4_dir_entries().unwrap();
+
+        let mut name_iter = name.iter().skip(start_idx);
+        let mut inode_type_iter = inode_type.iter().skip(start_idx);
+
+        for (i, out_entry) in dirents.iter_mut().enumerate() {
+            let iname = name_iter.next();
+            let itypes = inode_type_iter.next();
+
+            match itypes {
+                Some(t) => {
+                    let ty = if *t == InodeTypes::EXT4_DE_DIR {
+                        VfsNodeType::Dir
+                    } else if *t == InodeTypes::EXT4_DE_REG_FILE {
+                        VfsNodeType::File
+                    } else if *t == InodeTypes::EXT4_DE_SYMLINK {
+                        VfsNodeType::SymLink
+                    } else {
+                        error!("unknown file type: {:?}", itypes);
+                        unreachable!()
+                    };
+
+                    *out_entry =
+                        VfsDirEntry::new(core::str::from_utf8(iname.unwrap()).unwrap(), ty);
+                }
+                _ => return Ok(i),
+            }
+        }
+
+        Ok(dirents.len())
+    }
+
+    /// Lookup the node with given `path` in the directory.
+    /// Return the node if found.
+    fn lookup(self: Arc<Self>, path: &str) -> VfsResult<VfsNodeRef> {
+        debug!("lookup ext4fs: {:?}, {}", self.0.lock().get_path(), path);
+
+        let fpath = self.path_deal_with(path);
+        let fpath = fpath.as_str();
+        if fpath.is_empty() {
+            return Ok(self.clone());
+        }
+
+        /////////
+        let mut file = self.0.lock();
+        if file.check_inode_exist(fpath, InodeTypes::EXT4_DE_DIR) {
+            debug!("lookup new DIR FileWrapper");
+            Ok(Arc::new(Self::new(fpath, InodeTypes::EXT4_DE_DIR)))
+        } else if file.check_inode_exist(fpath, InodeTypes::EXT4_DE_REG_FILE) {
+            debug!("lookup new FILE FileWrapper");
+            Ok(Arc::new(Self::new(fpath, InodeTypes::EXT4_DE_REG_FILE)))
+        } else {
+            Err(VfsError::NotFound)
+        }
+    }
+
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> VfsResult<usize> {
+        let mut file = self.0.lock();
+        let path = file.get_path();
+        let path = path.to_str().unwrap();
+        file.file_open(path, O_RDONLY)
+            .map_err(|e| <i32 as TryInto<AxError>>::try_into(e).unwrap())?;
+
+        file.file_seek(offset as i64, SEEK_SET)
+            .map_err(|e| <i32 as TryInto<AxError>>::try_into(e).unwrap())?;
+        let r = file.file_read(buf);
+
+        let _ = file.file_close();
+        r.map_err(|e| e.try_into().unwrap())
+    }
+
+    fn write_at(&self, offset: u64, buf: &[u8]) -> VfsResult<usize> {
+        let mut file = self.0.lock();
+        let path = file.get_path();
+        let path = path.to_str().unwrap();
+        file.file_open(path, O_RDWR)
+            .map_err(|e| <i32 as TryInto<AxError>>::try_into(e).unwrap())?;
+
+        file.file_seek(offset as i64, SEEK_SET)
+            .map_err(|e| <i32 as TryInto<AxError>>::try_into(e).unwrap())?;
+        let r = file.file_write(buf);
+
+        let _ = file.file_close();
+        r.map_err(|e| e.try_into().unwrap())
+    }
+
+    fn truncate(&self, size: u64) -> VfsResult {
+        let mut file = self.0.lock();
+        let path = file.get_path();
+        let path = path.to_str().unwrap();
+        file.file_open(path, O_RDWR | O_CREAT | O_TRUNC)
+            .map_err(|e| <i32 as TryInto<AxError>>::try_into(e).unwrap())?;
+
+        let t = file.file_truncate(size);
+
+        let _ = file.file_close();
+        t.map(|_v| ()).map_err(|e| e.try_into().unwrap())
+    }
+
+    fn rename(&self, src_path: &str, dst_path: &str) -> VfsResult {
+        let mut file = self.0.lock();
+        file.file_rename(src_path, dst_path)
+            .map(|_v| ())
+            .map_err(|e| e.try_into().unwrap())
+    }
+
+    fn as_any(&self) -> &dyn core::any::Any {
+        self as &dyn core::any::Any
+    }
+}
+
+impl Drop for FileWrapper {
+    fn drop(&mut self) {
+        let mut file = self.0.lock();
+        debug!("Drop struct FileWrapper {:?}", file.get_path());
+        file.file_close().expect("failed to close fd");
+        drop(file); // todo
+    }
+}
+
+impl KernelDevOp for Disk {
+    //type DevType = Box<Disk>;
+    type DevType = Disk;
+
+    fn read(dev: &mut Disk, mut buf: &mut [u8]) -> Result<usize, i32> {
+        debug!("READ block device buf={}", buf.len());
+        let mut read_len = 0;
+        while !buf.is_empty() {
+            match dev.read_one(buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let tmp = buf;
+                    buf = &mut tmp[n..];
+                    read_len += n;
+                }
+                Err(_e) => return Err(-1),
+            }
+        }
+        debug!("READ rt len={}", read_len);
+        Ok(read_len)
+    }
+    fn write(dev: &mut Self::DevType, mut buf: &[u8]) -> Result<usize, i32> {
+        debug!("WRITE block device buf={}", buf.len());
+        let mut write_len = 0;
+        while !buf.is_empty() {
+            match dev.write_one(buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    buf = &buf[n..];
+                    write_len += n;
+                }
+                Err(_e) => return Err(-1),
+            }
+        }
+        debug!("WRITE rt len={}", write_len);
+        Ok(write_len)
+    }
+    fn flush(_dev: &mut Self::DevType) -> Result<usize, i32> {
+        Ok(0)
+    }
+    fn seek(dev: &mut Disk, off: i64, whence: i32) -> Result<i64, i32> {
+        let size = dev.size();
+        debug!(
+            "SEEK block device size:{}, pos:{}, offset={}, whence={}",
+            size,
+            &dev.position(),
+            off,
+            whence
+        );
+        let new_pos = match whence as u32 {
+            SEEK_SET => Some(off),
+            SEEK_CUR => dev.position().checked_add_signed(off).map(|v| v as i64),
+            SEEK_END => size.checked_add_signed(off).map(|v| v as i64),
+            _ => {
+                error!("invalid seek() whence: {}", whence);
+                Some(off)
+            }
+        }
+        .ok_or(-1)?;
+
+        if new_pos as u64 > size {
+            warn!("Seek beyond the end of the block device");
+        }
+        dev.set_position(new_pos as u64);
+        Ok(new_pos)
+    }
+}

--- a/modules/axfs/src/fs/lwext4_rust.rs
+++ b/modules/axfs/src/fs/lwext4_rust.rs
@@ -46,7 +46,7 @@ impl VfsOps for Ext4FileSystem {
     // mount()
 
     fn root_dir(&self) -> VfsNodeRef {
-        debug!("Get root_dir");
+        trace!("Get root_dir");
         //let root_dir = unsafe { (*self.root.get()).as_ref().unwrap() };
         Arc::clone(&self.root)
     }
@@ -250,7 +250,7 @@ impl VfsNodeOps for FileWrapper {
     /// Lookup the node with given `path` in the directory.
     /// Return the node if found.
     fn lookup(self: Arc<Self>, path: &str) -> VfsResult<VfsNodeRef> {
-        debug!("lookup ext4fs: {:?}, {}", self.0.lock().get_path(), path);
+        trace!("lookup ext4fs: {:?}, {}", self.0.lock().get_path(), path);
 
         let fpath = self.path_deal_with(path);
         let fpath = fpath.as_str();
@@ -261,10 +261,10 @@ impl VfsNodeOps for FileWrapper {
         /////////
         let mut file = self.0.lock();
         if file.check_inode_exist(fpath, InodeTypes::EXT4_DE_DIR) {
-            debug!("lookup new DIR FileWrapper");
+            trace!("lookup new DIR FileWrapper");
             Ok(Arc::new(Self::new(fpath, InodeTypes::EXT4_DE_DIR)))
         } else if file.check_inode_exist(fpath, InodeTypes::EXT4_DE_REG_FILE) {
-            debug!("lookup new FILE FileWrapper");
+            trace!("lookup new FILE FileWrapper");
             Ok(Arc::new(Self::new(fpath, InodeTypes::EXT4_DE_REG_FILE)))
         } else {
             Err(VfsError::NotFound)
@@ -329,7 +329,7 @@ impl VfsNodeOps for FileWrapper {
 impl Drop for FileWrapper {
     fn drop(&mut self) {
         let mut file = self.0.lock();
-        debug!("Drop struct FileWrapper {:?}", file.get_path());
+        trace!("Drop struct FileWrapper {:?}", file.get_path());
         file.file_close().expect("failed to close fd");
         drop(file); // todo
     }
@@ -340,7 +340,7 @@ impl KernelDevOp for Disk {
     type DevType = Disk;
 
     fn read(dev: &mut Disk, mut buf: &mut [u8]) -> Result<usize, i32> {
-        debug!("READ block device buf={}", buf.len());
+        trace!("READ block device buf={}", buf.len());
         let mut read_len = 0;
         while !buf.is_empty() {
             match dev.read_one(buf) {
@@ -353,11 +353,11 @@ impl KernelDevOp for Disk {
                 Err(_e) => return Err(-1),
             }
         }
-        debug!("READ rt len={}", read_len);
+        trace!("READ rt len={}", read_len);
         Ok(read_len)
     }
     fn write(dev: &mut Self::DevType, mut buf: &[u8]) -> Result<usize, i32> {
-        debug!("WRITE block device buf={}", buf.len());
+        trace!("WRITE block device buf={}", buf.len());
         let mut write_len = 0;
         while !buf.is_empty() {
             match dev.write_one(buf) {
@@ -369,7 +369,7 @@ impl KernelDevOp for Disk {
                 Err(_e) => return Err(-1),
             }
         }
-        debug!("WRITE rt len={}", write_len);
+        trace!("WRITE rt len={}", write_len);
         Ok(write_len)
     }
     fn flush(_dev: &mut Self::DevType) -> Result<usize, i32> {
@@ -377,7 +377,7 @@ impl KernelDevOp for Disk {
     }
     fn seek(dev: &mut Disk, off: i64, whence: i32) -> Result<i64, i32> {
         let size = dev.size();
-        debug!(
+        trace!(
             "SEEK block device size:{}, pos:{}, offset={}, whence={}",
             size,
             &dev.position(),

--- a/modules/axfs/src/fs/mod.rs
+++ b/modules/axfs/src/fs/mod.rs
@@ -1,9 +1,12 @@
 cfg_if::cfg_if! {
     if #[cfg(feature = "myfs")] {
         pub mod myfs;
+    } else if #[cfg(feature = "lwext4_rs")] {
+        pub mod lwext4_rust;
     } else if #[cfg(feature = "fatfs")] {
         pub mod fatfs;
     }
+
 }
 
 #[cfg(feature = "devfs")]

--- a/modules/axfs/src/lib.rs
+++ b/modules/axfs/src/lib.rs
@@ -33,6 +33,7 @@ mod root;
 
 pub mod api;
 pub mod fops;
+pub use root::{CURRENT_DIR, CURRENT_DIR_PATH};
 
 use axdriver::{AxDeviceContainer, prelude::*};
 

--- a/modules/axfs/tests/test_common/mod.rs
+++ b/modules/axfs/tests/test_common/mod.rs
@@ -201,8 +201,7 @@ fn test_devfs_ramfs() -> Result<()> {
 
     // stat /dev
     let dname = "/dev";
-    let dir = File::open(dname)?;
-    let md = dir.metadata()?;
+    let md = fs::metadata(dname)?;
     println!("metadata of {:?}: {:?}", dname, md);
     assert_eq!(md.file_type(), FileType::Dir);
     assert!(!md.is_file());
@@ -210,8 +209,7 @@ fn test_devfs_ramfs() -> Result<()> {
 
     // stat /dev/foo/bar
     let fname = ".//.///././/./dev///.///./foo//././bar";
-    let file = File::open(fname)?;
-    let md = file.metadata()?;
+    let md = fs::metadata(fname)?;
     println!("metadata of {:?}: {:?}", fname, md);
     assert_eq!(md.file_type(), FileType::CharDevice);
     assert!(!md.is_dir());

--- a/modules/axhal/src/platform/riscv64_qemu_virt/mod.rs
+++ b/modules/axhal/src/platform/riscv64_qemu_virt/mod.rs
@@ -20,6 +20,8 @@ unsafe extern "C" {
 unsafe extern "C" fn rust_entry(cpu_id: usize, dtb: usize) {
     crate::mem::clear_bss();
     crate::cpu::init_primary(cpu_id);
+    #[cfg(feature = "uspace")]
+    riscv::register::sstatus::set_sum();
     self::time::init_early();
     rust_main(cpu_id, dtb);
 }

--- a/ulib/axstd/Cargo.toml
+++ b/ulib/axstd/Cargo.toml
@@ -48,6 +48,7 @@ sched_cfs = ["axfeat/sched_cfs"]
 # File system
 fs = ["arceos_api/fs", "axfeat/fs"]
 myfs = ["arceos_api/myfs", "axfeat/myfs"]
+lwext4_rs = ["axfeat/lwext4_rs"]
 
 # Networking
 net = ["arceos_api/net", "axfeat/net"]


### PR DESCRIPTION
包含以下与文件系统有关的若干commit：
072da77 | feat(hal): improve context with more api(#29) *该commmit部分合并至此
3b33f3a | fix: not need `OpenOption::execute` for dir open (#19)
599cab4 | chore: use write_impl for syscall_writev(#17)
ea15dca | Upgrade axio to 0.1.1 and optimize default_read_to_end
43e16ba | Update `flatten_objects` version & Fix `check_region_access` (#9) *该commmit部分合并至此
c0882f4 | chore: update flatten_objects to 0.2.3
59d2cff | fix: incorrect writev implementation
3c5add1 | [fix] FD_TABLE clone
1a44ca5 | [fix] sys_writev return value
deaa373 | update toolchain
4007982 | [feat] Support for ext4 junior *该commmit部分合并至此


