### PR TITLE
任务管理axtask相关commit并入主线

### DIFF
--- a/.github/workflows/actions/setup-musl/action.yml
+++ b/.github/workflows/actions/setup-musl/action.yml
@@ -23,7 +23,7 @@ runs:
       if [ "${{ inputs.arch }}" = "loongarch64" ]; then
         wget https://github.com/LoongsonLab/oscomp-toolchains-for-oskernel/releases/download/loongarch64-linux-musl-cross-gcc-13.2.0/loongarch64-linux-musl-cross.tgz
       else
-        wget https://musl.cc/${MUSL_PATH}.tgz
+        wget https://github.com/elebirds/musl-save/releases/download/musl/${MUSL_PATH}.tgz
       fi
       tar -xf ${MUSL_PATH}.tgz
   - uses: actions/cache/save@v4

--- a/modules/axtask/src/api.rs
+++ b/modules/axtask/src/api.rs
@@ -1,6 +1,9 @@
 //! Task APIs for multi-task configuration.
 
-use alloc::{string::String, sync::Arc};
+use alloc::{
+    string::String,
+    sync::{Arc, Weak},
+};
 
 use kernel_guard::NoPreemptIrqSave;
 
@@ -15,6 +18,11 @@ pub use crate::wait_queue::WaitQueue;
 
 /// The reference type of a task.
 pub type AxTaskRef = Arc<AxTask>;
+
+/// The weak reference type of a task.
+pub type WeakAxTaskRef = Weak<AxTask>;
+
+pub use crate::task::TaskState;
 
 /// The wrapper type for [`cpumask::CpuMask`] with SMP configuration.
 pub type AxCpuMask = cpumask::CpuMask<{ axconfig::SMP }>;

--- a/modules/axtask/src/task.rs
+++ b/modules/axtask/src/task.rs
@@ -23,7 +23,7 @@ pub struct TaskId(u64);
 /// The possible states of a task.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub(crate) enum TaskState {
+pub enum TaskState {
     /// Task is running on some CPU.
     Running = 1,
     /// Task is ready to run on some scheduler's ready queue.
@@ -38,7 +38,7 @@ pub(crate) enum TaskState {
 /// The inner task structure.
 pub struct TaskInner {
     id: TaskId,
-    name: String,
+    name: UnsafeCell<String>,
     is_idle: bool,
     is_init: bool,
 
@@ -123,7 +123,7 @@ impl TaskInner {
         t.entry = Some(Box::into_raw(Box::new(entry)));
         t.ctx_mut().init(task_entry as usize, kstack.top(), tls);
         t.kstack = Some(kstack);
-        if t.name == "idle" {
+        if t.name() == "idle" {
             t.is_idle = true;
         }
         t
@@ -136,12 +136,19 @@ impl TaskInner {
 
     /// Gets the name of the task.
     pub fn name(&self) -> &str {
-        self.name.as_str()
+        unsafe { (*self.name.get()).as_str() }
+    }
+
+    /// Set the name of the task.
+    pub fn set_name(&self, name: &str) {
+        unsafe {
+            *self.name.get() = String::from(name);
+        }
     }
 
     /// Get a combined string of the task ID and name.
     pub fn id_name(&self) -> alloc::string::String {
-        alloc::format!("Task({}, {:?})", self.id.as_u64(), self.name)
+        alloc::format!("Task({}, {:?})", self.id.as_u64(), self.name())
     }
 
     /// Wait for the task to exit, and return the exit code.
@@ -209,6 +216,20 @@ impl TaskInner {
     pub fn set_cpumask(&self, cpumask: AxCpuMask) {
         *self.cpumask.lock() = cpumask
     }
+
+    /// Read the top address of the kernel stack for the task.
+    #[inline]
+    pub fn get_kernel_stack_top(&self) -> Option<usize> {
+        if let Some(kstack) = &self.kstack {
+            return Some(kstack.top().as_usize());
+        }
+        None
+    }
+
+    /// Returns the exit code of the task.
+    pub fn exit_code(&self) -> i32 {
+        self.exit_code.load(Ordering::Acquire)
+    }
 }
 
 // private methods
@@ -216,7 +237,7 @@ impl TaskInner {
     fn new_common(id: TaskId, name: String) -> Self {
         Self {
             id,
-            name,
+            name: UnsafeCell::new(name),
             is_idle: false,
             is_init: false,
             entry: None,
@@ -255,7 +276,7 @@ impl TaskInner {
         t.is_init = true;
         #[cfg(feature = "smp")]
         t.set_on_cpu(true);
-        if t.name == "idle" {
+        if t.name() == "idle" {
             t.is_idle = true;
         }
         t
@@ -265,13 +286,15 @@ impl TaskInner {
         Arc::new(AxTask::new(self))
     }
 
+    /// Returns the task's current state.
     #[inline]
-    pub(crate) fn state(&self) -> TaskState {
+    pub fn state(&self) -> TaskState {
         self.state.load(Ordering::Acquire).into()
     }
 
+    /// Set the task's state.
     #[inline]
-    pub(crate) fn set_state(&self, state: TaskState) {
+    pub fn set_state(&self, state: TaskState) {
         self.state.store(state as u8, Ordering::Release)
     }
 

--- a/modules/axtask/src/task.rs
+++ b/modules/axtask/src/task.rs
@@ -519,7 +519,9 @@ impl CurrentTask {
     pub(crate) unsafe fn init_current(init_task: AxTaskRef) {
         assert!(init_task.is_init());
         #[cfg(feature = "tls")]
-        axhal::arch::write_thread_pointer(init_task.tls.tls_ptr() as usize);
+        unsafe {
+            axhal::arch::write_thread_pointer(init_task.tls.tls_ptr() as usize);
+        }
         let ptr = Arc::into_raw(init_task);
         unsafe {
             axhal::cpu::set_current_task_ptr(ptr);

--- a/modules/axtask/src/task_ext.rs
+++ b/modules/axtask/src/task_ext.rs
@@ -11,6 +11,10 @@ static __AX_TASK_EXT_SIZE: usize = 0;
 #[linkage = "weak"]
 static __AX_TASK_EXT_ALIGN: usize = 0;
 
+#[unsafe(no_mangle)]
+#[linkage = "weak"]
+fn __ax_task_ext_drop(_data: *mut u8) {}
+
 /// A wrapper of pointer to the task extended data.
 pub(crate) struct AxTaskExt {
     ptr: *mut u8,
@@ -102,7 +106,12 @@ impl AxTaskExt {
 impl Drop for AxTaskExt {
     fn drop(&mut self) {
         if !self.ptr.is_null() {
-            let layout = Layout::from_size_align(Self::size(), 0x10).unwrap();
+            unsafe extern "C" {
+                fn __ax_task_ext_drop(data: *mut u8);
+            }
+            unsafe { __ax_task_ext_drop(self.ptr) };
+
+            let layout = Layout::from_size_align(Self::size(), Self::align()).unwrap();
             unsafe { alloc::alloc::dealloc(self.ptr, layout) };
         }
     }
@@ -163,6 +172,11 @@ macro_rules! def_task_ext {
 
         #[unsafe(no_mangle)]
         static __AX_TASK_EXT_ALIGN: usize = ::core::mem::align_of::<$task_ext_struct>();
+
+        #[unsafe(no_mangle)]
+        fn __ax_task_ext_drop(data: *mut u8) {
+            unsafe { core::ptr::drop_in_place(data as *mut $task_ext_struct) };
+        }
 
         impl $crate::TaskExtRef<$task_ext_struct> for $crate::TaskInner {
             fn task_ext(&self) -> &$task_ext_struct {

--- a/modules/axtask/src/wait_queue.rs
+++ b/modules/axtask/src/wait_queue.rs
@@ -206,14 +206,16 @@ impl WaitQueue {
     /// Requeues at most `count` tasks in the wait queue to the target wait queue.
     ///
     /// Returns the number of tasks requeued.
-    pub fn requeue(&self, count: usize, target: &WaitQueue) -> usize {
+    pub fn requeue(&self, mut count: usize, target: &WaitQueue) -> usize {
         let tasks: Vec<_> = {
             let mut wq = self.queue.lock();
-            let count = count.min(wq.len());
+            count = count.min(wq.len());
             wq.drain(..count).collect()
         };
-        let mut wq = target.queue.lock();
-        wq.extend(tasks);
+        if !tasks.is_empty() {
+            let mut wq = target.queue.lock();
+            wq.extend(tasks);
+        }
         count
     }
 

--- a/modules/axtask/src/wait_queue.rs
+++ b/modules/axtask/src/wait_queue.rs
@@ -216,6 +216,16 @@ impl WaitQueue {
         wq.extend(tasks);
         count
     }
+
+    /// Returns the number of tasks in the wait queue.
+    pub fn len(&self) -> usize {
+        self.queue.lock().len()
+    }
+
+    /// Returns true if the wait queue is empty.
+    pub fn is_empty(&self) -> bool {
+        self.queue.lock().is_empty()
+    }
 }
 
 fn unblock_one_task(task: AxTaskRef, resched: bool) {


### PR DESCRIPTION
包含以下与任务管理axtask有关的若干commit：

4afefff | fix: `WaitQueue::requeue` wrong implementation (#40)
14963b1 | feat: add `WaitQueue::len` and `WaitQueue::is_empty` (#39)
99c579b | Add post trap handler to support signal (#34) *该commmit部分合并至此
b8434b4 | Fix ip bump and tls isolation for hal (#35) *该commmit部分合并至此
192f072 | Fix TaskExt drop issue & properly unmap PTEs in `AddrSpace::drop` (#20) *该commmit部分合并至此
4007982 | [feat] Support for ext4 junior *该commmit部分合并至此
